### PR TITLE
Fixed logs starting limit for dashboard.

### DIFF
--- a/extension.driver.php
+++ b/extension.driver.php
@@ -947,7 +947,7 @@
 					}
 
 					Administration::instance()->Page->addStylesheetToHead(URL . '/extensions/tracker/assets/' . 'dashboard.css', 'screen', 151);
-					$logs = Tracker::fetchActivities($filters, (int)$config['limit'], 1);
+					$logs = Tracker::fetchActivities($filters, (int)$config['limit'], 0);
 
 					$thead = array(
 						array(__('Activity'), 'col'),


### PR DESCRIPTION
Last entry in the logs was missing from dashboard panel. This patch fixes this.
