### PR TITLE
PHP error when using Limit Section Entries

### DIFF
--- a/lib/class.tracker.php
+++ b/lib/class.tracker.php
@@ -264,21 +264,27 @@
 			// Otherwise grab the primary field value and build the entry string
 			else {
 				$primary_field = reset($section->fetchVisibleColumns());
-				$data = $entry->getData($primary_field->get('id'));
-				$value = $primary_field->prepareTableValue($data);
-			
-				// If we're creating the fallback, just return a string
-				if($fallback) {
-					$entry_string = $value;
-				}
-			
-				// Otherwise build a link to the entry
-				else {				
-					$entry_string = Widget::Anchor(
-						$value,
-						URL . '/symphony/publish/' . $section->get('handle') . '/edit/' . $activity['item_id']
-					)->generate();
-				}
+				if ($primary_field) {
+					$data = $entry->getData($primary_field->get('id'));
+					$value = $primary_field->prepareTableValue($data);
+				
+					// If we're creating the fallback, just return a string
+					if($fallback) {
+						$entry_string = $value;
+					}
+				
+					// Otherwise build a link to the entry
+					else {				
+						$entry_string = Widget::Anchor(
+							$value,
+							URL . '/symphony/publish/' . $section->get('handle') . '/edit/' . $activity['item_id']
+						)->generate();
+					}
+				} 
+				// using limit section entries?
+				else {
+					$fallback = true;
+				} 
 			}
 			
 			// If the section no longer exists, get the fallback section description


### PR DESCRIPTION
Hello,

This is a bit of a hack/patch as I am not completely sure what is going on. But if a section has limited entries with the Limit Section Entries plugin, or is using the deprecated Static Section, upon saving an entry the following PHP error is thrown:

```
Fatal error: Call to a member function get() on a non-object in /extensions/tracker/lib/class.tracker.php on line 267
```

I have added a work around to which prevents the error from being thrown. I believe leaving the nicest logs in the tracker, therefore could be improved.

Thanks,
Ross
