### PR TITLE
Allow notifications to multiple urls

### DIFF
--- a/extension.driver.php
+++ b/extension.driver.php
@@ -654,6 +654,9 @@ class Extension_Tracker extends Extension
 
     public function validateSection($id)
     {
+        if (is_null($id)) {
+            return TRUE;
+        }
         if (in_array($id, $this->getExclusions('sections'))) {
             return FALSE;
         } else {

--- a/extension.meta.xml
+++ b/extension.meta.xml
@@ -17,6 +17,7 @@
 	<releases>
 		<release version="1.4.1" date="2016-03-09" min="2.5" max="2.6.x">
 			- Added support for notifying multiple URLs
+			- Log entry delete events
 		</release>
 		<release version="1.4.0" date="2015-06-24" min="2.5" max="2.6.x">
 			- Fixed author deletion

--- a/extension.meta.xml
+++ b/extension.meta.xml
@@ -15,6 +15,9 @@
 		</author>
 	</authors>
 	<releases>
+		<release version="1.4.1" date="2016-03-09" min="2.5" max="2.6.x">
+			- Added support for notifying multiple URLs
+		</release>
 		<release version="1.4.0" date="2015-06-24" min="2.5" max="2.6.x">
 			- Fixed author deletion
 			- Added tracking of front-end members

--- a/lib/class.tracker.php
+++ b/lib/class.tracker.php
@@ -69,9 +69,10 @@
 
 			// Send the event to the URL if specificed
 			$notify_url = Symphony::Configuration()->get('notify_url', 'tracker');
-			if ($notify_url) {
+			$notify_urls_array = preg_split('/[\s,]+/', $notify_url);
+			foreach($notify_urls_array as $url) {
 				$gateway = new Gateway;
-				$gateway->init($notify_url . "?". http_build_query($data));
+				$gateway->init($url . "?". http_build_query($data));
 				$gateway->exec();
 			}
 		}


### PR DESCRIPTION
I’ve been using this minor modification to notify multiple urls at the same time. The reason why I’m using this is that our notification url exists on localhost (for testing) and on a domain.

I can’t see any drawback to puling this in… so here it is. Let me know if you’d like me to change anything.