### PR TITLE
Set Author Id to null if no author is set

### DIFF
--- a/extension.driver.php
+++ b/extension.driver.php
@@ -684,7 +684,7 @@ class Extension_Tracker extends Extension
 
     public function getAuthorID()
     {
-        return Symphony::Author()->get('id');
+        return !empty(Symphony::Author()) ? Symphony::Author()->get('id') : null;
     }
 
     public function getTimestamp()


### PR DESCRIPTION
Simple fix to set the ID to null if no author is set.